### PR TITLE
Fix solar radiance not working in void worlds

### DIFF
--- a/src/main/java/com/mrbysco/enchantableblocks/block/blockentity/furnace/AbstractEnchantedFurnaceBlockEntity.java
+++ b/src/main/java/com/mrbysco/enchantableblocks/block/blockentity/furnace/AbstractEnchantedFurnaceBlockEntity.java
@@ -58,7 +58,8 @@ public abstract class AbstractEnchantedFurnaceBlockEntity extends AbstractFurnac
 		boolean changed = false;
 		boolean hasInput = !blockEntity.items.getFirst().isEmpty();
 		boolean solar = blockEntity.hasEnchantment(EnchantmentUtil.getEnchantmentHolder(level, ModEnchantments.SOLAR_RADIANCE));
-		boolean solarRequirements = level.isDay() && level.canSeeSky(pos.above());
+		// If dimension has a fixed time (Level#isDay() always returns false there), check against the sky darkness directly (same as Level#isDay's impl)
+		boolean solarRequirements = (level.isDay() || (level.dimensionType().hasFixedTime() && level.getSkyDarken() < 4)) && level.canSeeSky(pos.above());
 
 		if (blockEntity.isLit()) {
 			int speed = blockEntity.getSpeed();


### PR DESCRIPTION
This PR fixes #6 by adjusting the solar radiance check in `AbstractEnchantedFurnaceBlockEntity` to check against the sky darkness directly for dimensions with fixed time, as does the void world from the [Just Another Void Dimension](https://www.curseforge.com/minecraft/mc-mods/javd) mod.

Void worlds may have the dimension set to fixed time, in which case `Level#isDay()` will always return false. To workaround that, we check against the sky darkness (the same as what `Level#isDay()` does) for dimensions with fixed time.

The original `Level#isDay()` check is kept in case it is overridden by some mod for a custom implementation of Level.

Note that the concept of fixed time used by `Level#isDay()` is from the _dimension type_; it is separate from the concept of 'having fixed time' due to disabling the daylight cycle through the gamerule. In the latter case, the level daytime is not fixed, but frozen since it is not updated (and the daytime can still be moved about, which isn't possible for fixed-time dimension types).

**Post-merge edit:** Here's a screenshot of the fix:

![A furnace enchanted with Solar Radiance I cooking charcoal in a void dimension](https://github.com/user-attachments/assets/87f53146-5fd4-44cf-9534-736de0bff48e)